### PR TITLE
과제 조회 응답에 시작날짜, 종료날짜 같이 보냄

### DIFF
--- a/src/main/java/algogather/api/dto/studyroom/AssignmentResponseDto.java
+++ b/src/main/java/algogather/api/dto/studyroom/AssignmentResponseDto.java
@@ -18,6 +18,8 @@ public class AssignmentResponseDto {
                             new AssignmentInfo(
                                     assignmentWithSolvedUserDto.getAssignmentProblem().getProblem().getPid(),
                                     assignmentWithSolvedUserDto.getAssignmentProblem().getProblem().getTitle(),
+                                    assignmentWithSolvedUserDto.getAssignmentProblem().getStartDate(),
+                                    assignmentWithSolvedUserDto.getAssignmentProblem().getDueDate(),
                                     assignmentWithSolvedUserDto.getAssignmentProblem().getProblem().getDifficulty().getLevel(),
                                     assignmentWithSolvedUserDto.getAssignmentProblem().getProblem().getDifficulty().getName(),
 
@@ -38,6 +40,8 @@ public class AssignmentResponseDto {
     static class AssignmentInfo {
         private Long problemPid;
         private String problemTitle;
+        private LocalDateTime startDate;
+        private LocalDateTime dueDate;
         private Long problemDifficultyLevel;
         private String problemDifficultyName;
         private List<SolvedUserInfo> solvedUserInfoList;


### PR DESCRIPTION
### 과제 조회 응답에 시작날짜, 종료날짜 같이 보냄
<img width="1013" alt="스크린샷 2023-11-01 오전 12 18 33" src="https://github.com/cau-overchaos/backend-api/assets/83588265/d589cda9-9a4d-421a-97ee-ca4508426362">
