### PR TITLE
좌표 정보 보내는 소켓 러프하게 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'org.springframework.security:spring-security-messaging'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/algogather/api/config/WebSocketConfig.java
+++ b/src/main/java/algogather/api/config/WebSocketConfig.java
@@ -1,0 +1,27 @@
+package algogather.api.config;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.support.HttpSessionHandshakeInterceptor;
+
+@Configuration
+@EnableWebSocket
+@RequiredArgsConstructor
+@Slf4j
+public class WebSocketConfig implements WebSocketConfigurer {
+
+    private final WebSocketHandler webSocketHandler;
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(webSocketHandler, "/ws/draw")
+                .addInterceptors(new HttpSessionHandshakeInterceptor()) // interceptor for adding httpsession into websocket session
+                .setAllowedOrigins("*");
+    }
+}

--- a/src/main/java/algogather/api/dto/draw/MessageRequestDto.java
+++ b/src/main/java/algogather/api/dto/draw/MessageRequestDto.java
@@ -1,0 +1,26 @@
+package algogather.api.dto.draw;
+
+import lombok.*;
+
+import javax.validation.constraints.NotNull;
+
+@Builder
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MessageRequestDto {
+    public enum MessageType {
+        ENTER, DRAW, QUIT
+    }
+
+    @NotNull
+    private MessageType messageType; // 공유소스코드 그림판 입장 여부
+
+    @NotNull
+    private Long sharedSourceCodeId;
+
+    private String messageText;
+
+    private PointRequestDto pointRequestDto;
+}

--- a/src/main/java/algogather/api/dto/draw/PointRequestDto.java
+++ b/src/main/java/algogather/api/dto/draw/PointRequestDto.java
@@ -8,16 +8,16 @@ import javax.validation.constraints.NotNull;
 @Getter
 @Setter
 public class PointRequestDto {
-    public enum IsDelete {
-        YES, NO
-    }
-
     @NotNull
-    private IsDelete isDelete;
+    private boolean isDelete;
     @NotNull
-    private Long x;
+    private Long startX;
     @NotNull
-    private Long y;
+    private Long startY;
+    @NotNull
+    private Long endX;
+    @NotNull
+    private Long endY;
     @NotNull
     private String color;
 }

--- a/src/main/java/algogather/api/dto/draw/PointRequestDto.java
+++ b/src/main/java/algogather/api/dto/draw/PointRequestDto.java
@@ -1,0 +1,23 @@
+package algogather.api.dto.draw;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Setter
+public class PointRequestDto {
+    public enum IsDelete {
+        YES, NO
+    }
+
+    @NotNull
+    private IsDelete isDelete;
+    @NotNull
+    private Long x;
+    @NotNull
+    private Long y;
+    @NotNull
+    private String color;
+}

--- a/src/main/java/algogather/api/service/sharedsourcecode/SharedSourceCodeService.java
+++ b/src/main/java/algogather/api/service/sharedsourcecode/SharedSourceCodeService.java
@@ -108,6 +108,11 @@ public class SharedSourceCodeService {
         return sharedSourceCode;
     }
 
+    public SharedSourceCode findById(Long sourceCodeId) {
+
+        return sharedSourceCodeRepository.findById(sourceCodeId).orElseThrow(SharedSourceCodeNotFoundException::new);
+    }
+
     private void validateSharedSourceMatchingWithStudyRoom(SharedSourceCode sharedSourceCode, StudyRoom studyRoom) {
         sharedSourceCodeRepository.findByIdAndStudyRoomId(sharedSourceCode.getId(), studyRoom.getId()).orElseThrow(SharedSourceCodeAndStudyRoomNotMatchingException::new);
     }

--- a/src/main/java/algogather/api/socket/WebSocketDrawHandler.java
+++ b/src/main/java/algogather/api/socket/WebSocketDrawHandler.java
@@ -1,0 +1,109 @@
+package algogather.api.socket;
+
+
+import algogather.api.domain.sharedsourcecode.SharedSourceCode;
+import algogather.api.domain.user.UserAdapter;
+import algogather.api.dto.draw.MessageRequestDto;
+import algogather.api.service.sharedsourcecode.SharedSourceCodeService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketDrawHandler extends TextWebSocketHandler {
+    private final ObjectMapper mapper;
+    private final Set<WebSocketSession> sessions = new HashSet<>();
+    private final Map<Long, Set<WebSocketSession>> sharedSourceCodeSessionMap = new HashMap<>();
+
+    private final SharedSourceCodeService sharedSourceCodeService;
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        log.debug("{} 연결됨", session.getId());
+
+        SecurityContextImpl o = (SecurityContextImpl) session.getAttributes().get("SPRING_SECURITY_CONTEXT");
+        UserAdapter principal = (UserAdapter) o.getAuthentication().getPrincipal();
+        log.debug("유저 아이디: " + principal.getUsername());
+
+        sessions.add(session);
+    }
+
+    @Override
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+        String payload = message.getPayload();
+        log.debug("payload {}", payload);
+
+        MessageRequestDto messageRequestDto = mapper.readValue(payload, MessageRequestDto.class);
+        log.debug("session {}", messageRequestDto.toString());
+
+        SecurityContextImpl o = (SecurityContextImpl) session.getAttributes().get("SPRING_SECURITY_CONTEXT");
+        UserAdapter principal = (UserAdapter) o.getAuthentication().getPrincipal();
+        log.debug("유저 아이디: " + principal.getUsername());
+
+        SharedSourceCode sharedSourceCode = sharedSourceCodeService.findById(messageRequestDto.getSharedSourceCodeId()); // 공유소스코드로 그림판을 구분한다
+        if(!sharedSourceCodeSessionMap.containsKey(sharedSourceCode.getId())) {
+            sharedSourceCodeSessionMap.put(sharedSourceCode.getId(), new HashSet<>());
+        }
+
+        Set<WebSocketSession> sharedSourceCodeSession = sharedSourceCodeSessionMap.get(sharedSourceCode.getId());
+
+        if(messageRequestDto.getMessageType().equals(MessageRequestDto.MessageType.ENTER)) { // messageType이 ENTER이면 해당 공유소스코드 그림판에 session 추가
+            sharedSourceCodeSession.add(session);
+            messageRequestDto.setMessageText(principal.getUsername() + " 님이 들어오셨습니다.");
+        }
+        else if (messageRequestDto.getMessageType().equals(MessageRequestDto.MessageType.QUIT)) {
+            sharedSourceCodeSession.remove(session);
+            messageRequestDto.setMessageText(principal.getUsername() + " 님이 나가셨습니다.");
+        }
+        else {
+            messageRequestDto.setMessageText(principal.getUsername() + " 좌표를 전송하였습니다");
+        }
+
+        if(sharedSourceCodeSession.size()>=3) {
+            removeClosedSession(sharedSourceCodeSession);
+        }
+
+        sendMessageToChatRoom(messageRequestDto, sharedSourceCodeSession);
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+        log.debug("{} 연결 끊김", session.getId());
+
+        SecurityContextImpl o = (SecurityContextImpl) session.getAttributes().get("SPRING_SECURITY_CONTEXT");
+        UserAdapter principal = (UserAdapter) o.getAuthentication().getPrincipal();
+        log.debug("유저 아이디: " + principal.getUsername());
+
+        sessions.remove(session);
+    }
+
+    private void removeClosedSession(Set<WebSocketSession> chatRoomSession) {
+        chatRoomSession.removeIf(sess -> !sessions.contains(sess));
+    }
+
+    private void sendMessageToChatRoom(MessageRequestDto chatMessageRequestDto, Set<WebSocketSession> chatRoomSession) {
+        chatRoomSession.parallelStream().forEach(sess -> sendMessage(sess, chatMessageRequestDto));
+    }
+
+    public <T> void sendMessage(WebSocketSession session, T message) {
+        try {
+            session.sendMessage(new TextMessage(mapper.writeValueAsString(message)));
+        } catch (IOException e) {
+            log.error(e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/algogather/api/socket/WebSocketDrawHandler.java
+++ b/src/main/java/algogather/api/socket/WebSocketDrawHandler.java
@@ -70,7 +70,7 @@ public class WebSocketDrawHandler extends TextWebSocketHandler {
             messageRequestDto.setMessageText(principal.getUsername() + " 님이 나가셨습니다.");
         }
         else {
-            messageRequestDto.setMessageText(principal.getUsername() + " 좌표를 전송하였습니다");
+            messageRequestDto.setMessageText(principal.getUsername() + " 님이 좌표를 전송하였습니다");
         }
 
         if(sharedSourceCodeSession.size()>=3) {


### PR DESCRIPTION
* 처음에 소켓 연결시 로그인한 유저만 연결 가능
* ws://localhost:8080/ws/draw 여기로 연결하고 데이터 보내면 됨
* 특정 공유소스코드에 대하여 그림판 방을 만들어서 거기에 속한 사용자끼리만 데이터 주고받음

* 데이터 JSON 포맷은 다음과 같음

- 특정 공유소스코드방 입장

```
{
"messageType": "ENTER",
    "sharedSourceCodeId": 1,
    "messageText": null,
    "pointRequestDto": null
}
```
messageText에 $$님이 입장하셨습니다. 라는 텍스트가 입력되어서 뿌려짐

- 그리기

```
{
"messageType": "DRAW",
    "sharedSourceCodeId": 1,
     "messageText": null,
    "pointRequestDto": {
        "isDelete": "YES", // 지우기, 안지우기 여부
        "x": 1,
        "y": 1,
        "color": null // 색깔 문자열 데이터
    }
}
```

- 나가기

```
{
"messageType": "DRAW",
    "sharedSourceCodeId": 1,
     "messageText": null,
    "pointRequestDto": {
        "isDelete": "YES", // 지우기, 안지우기 여부
        "x": 1,
        "y": 1,
        "color": null // 색깔 문자열 데이터
     }
}
```

messageText에 $$님이 나갔습니다 라는 텍스트가 입력되어서 뿌려짐


* 예외처리가 제대로 되어있지 않음. 예를들어서 존재하지 않는 공유소스코드로 보내면 연결이 끊어질 것임
![스크린샷 2023-11-25 오전 12 43 20](https://github.com/cau-overchaos/backend-api/assets/83588265/152b1b86-2189-4ada-bc33-5ef77c8a6cf9)
